### PR TITLE
Add Loops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 
 import Page from './components/page';
-import art from './art';
+import sketch from './demos/sketch';
+import loop from './demos/loop';
 
 const App = () => {
   return (
@@ -11,7 +12,7 @@ const App = () => {
         <title>Make Code Sketch</title>
         <meta name="description" content="Canvas sketch made by code" />
       </Helmet>
-      <Page sketch={art}></Page>
+      <Page sketch={sketch}></Page>
     </>
   );
 };

--- a/src/components/page/KeyboardHandler.ts
+++ b/src/components/page/KeyboardHandler.ts
@@ -1,4 +1,5 @@
 import StringMap from 'types/StringMap';
+import LoopState from './LoopState';
 import PageState from './PageState';
 
 const keyActionDescriptions: StringMap<string> = {
@@ -12,14 +13,26 @@ const keyActionDescriptions: StringMap<string> = {
   ArrowLeft: 'Previous Image seed',
   ArrowUp: 'Next Color seed',
   ArrowDown: 'Previous Color seed',
+
+  Enter: 'Pause Animation Loop',
+  NumpadEnter: 'Pause Animation Loop',
+
+  KeyR: 'Redraw Sketch and Restart Loop',
 };
 
 export default function KeyboardHandler(
   state: PageState,
+  loopState: LoopState,
   draw: () => void,
+  restart: () => void,
   download: () => void,
 ) {
   return function handler(event: KeyboardEvent) {
+    // This line gets complaints from the TypeScript linter, but runs in the browser without fail.
+    if (event.target && event.target.localTarget === 'input') {
+      return;
+    }
+
     // TODO: end function if keydown is in an input element
     const actionDescriptionLog = keyActionDescriptions[event.code]
       ? ` - ${keyActionDescriptions[event.code]}`
@@ -65,6 +78,16 @@ export default function KeyboardHandler(
       case 'ArrowDown':
         state.prevColor();
         draw();
+        break;
+
+      // ===== Animation Controls
+      case 'Enter':
+      case 'NumpadEnter':
+        loopState.togglePause();
+        break;
+
+      case 'KeyR':
+        restart();
         break;
 
       default:

--- a/src/components/page/LoopState.ts
+++ b/src/components/page/LoopState.ts
@@ -1,0 +1,68 @@
+import FrameData from 'src/sketch/FrameData';
+
+export default class LoopState {
+  finished: boolean;
+
+  animationFrameRequest?: number;
+
+  frameData: FrameData;
+
+  paused: boolean;
+
+  startTime: number;
+  lastTime: number;
+
+  constructor() {
+    this.finished = false;
+
+    this.frameData = {
+      frame: 0,
+      frameTime: 0,
+      totalTime: 0,
+    };
+
+    this.paused = false;
+
+    const start = Date.now();
+    this.startTime = start;
+    this.lastTime = start;
+  }
+
+  togglePause() {
+    this.paused = !this.paused;
+  }
+
+  nextFrame() {
+    if (this.paused || this.finished) {
+      return false;
+    }
+
+    const requestTime = Date.now();
+    const ticks = requestTime - this.lastTime;
+    if (ticks > 10) {
+      this.frameData.frame += 1;
+      this.frameData.frameTime = ticks;
+      this.frameData.totalTime += ticks;
+
+      this.lastTime = requestTime;
+
+      return true;
+    }
+    return false;
+  }
+
+  restart() {
+    this.finished = false;
+    this.paused = false;
+
+    this.frameData = {
+      frame: 0,
+      frameTime: 0,
+      totalTime: 0,
+    };
+
+    const start = Date.now();
+    this.startTime = start;
+    this.lastTime = start;
+  }
+}

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -192,6 +192,8 @@ const Page = (props: { sketch: Sketch }) => {
     if (!initialized) {
       console.log('### ===== Sketch! ===== ###');
       // ===== Initialize Sketch
+      resize();
+      getCanvas().set.size(config.width, config.height);
       sketch.init(getSketchProps());
 
       setInitialized(true);

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -182,7 +182,6 @@ const Page = (props: { sketch: Sketch }) => {
    * Run once on page load
    */
   useEffect(() => {
-    console.log('useEffect', initialized);
     // ===== Attach event handlers
     resetEventHandlers();
 

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -10,6 +10,7 @@ import Palette from '../../sketch/Palette';
 
 import Menu from '../menu';
 import StringMap from 'types/StringMap';
+import LoopState from './LoopState';
 import SketchProps from 'src/sketch/SketchProps';
 
 const FullscreenWrapper = styled.div`
@@ -56,16 +57,16 @@ const Page = (props: { sketch: Sketch }) => {
   const [state] = useState<PageState>(new PageState(config.seed));
   const [eventHandlers] = useState<any>({});
   const [params] = useState<StringMap<any>>(convertSketchParameters());
+  const [loopState] = useState<LoopState>(new LoopState());
+  const [sketchData] = useState<StringMap<any>>({});
 
-  let canvas: Canvas;
-  let sketchProps: SketchProps;
-
-  const updateSketchProps = () => {
-    sketchProps = {
-      canvas,
+  const getSketchProps: () => SketchProps = () => {
+    return {
+      canvas: getCanvas(),
       params,
       rng: state.getImageRng(),
       palette: new Palette(state.getColorRng()),
+      data: sketchData,
     };
   };
 
@@ -93,36 +94,58 @@ const Page = (props: { sketch: Sketch }) => {
         newHeight = (newWidth / config.width) * config.height;
       }
     }
+    const canvas = getCanvas();
     canvas.canvas.style.height = newHeight + 'px';
     canvas.canvas.style.width = newWidth + 'px';
   };
 
-  const draw = () => {
+  const restart = () => {
+    const sketchProps = getSketchProps();
+    sketch.reset(sketchProps);
+    sketch.init(sketchProps);
+    draw();
+    loopState.restart();
+  };
+
+  const getCanvas = () => {
     // Grab our canvas
     const pageCanvas = document.getElementById(
       'sketch-canvas',
     ) as HTMLCanvasElement;
-    canvas = new Canvas(pageCanvas);
-    // updateSketchProps();
+    return new Canvas(pageCanvas);
+  };
 
+  const draw = () => {
     // Set dimensions for window
     resize();
-
+    const sketchProps = getSketchProps();
     // Note: This size update is done pre-draw based on config props for the size.
     //      when this is run, the canvas bitmap content is lost, so do not do this in the resize loop.
-    canvas.set.size(config.width, config.height);
+    sketchProps.canvas.set.size(config.width, config.height);
 
     // TODO: Improve the state logging.
     console.log(state.getImage(), '-', state.getColor());
-    updateSketchProps();
-    sketch.draw(sketchProps);
+
+    sketch.draw(getSketchProps());
+
+    if (loopState.animationFrameRequest) {
+      window.cancelAnimationFrame(loopState.animationFrameRequest);
+    }
+
+    const animate = () => {
+      if (loopState.nextFrame()) {
+        loopState.finished = sketch.loop(getSketchProps(), loopState.frameData);
+      }
+      loopState.animationFrameRequest = window.requestAnimationFrame(animate);
+    };
+    animate();
   };
 
   const download = () => {
     const saveas = `${state.getImage()} - ${state.getColor()}.png`;
     const downloadLink = document.getElementById('canvas-downloader');
     if (downloadLink) {
-      const image = canvas.canvas.toDataURL('image/png');
+      const image = getCanvas().canvas.toDataURL('image/png');
       downloadLink.setAttribute('href', image);
       downloadLink.setAttribute('download', saveas);
       downloadLink.click();
@@ -141,7 +164,7 @@ const Page = (props: { sketch: Sketch }) => {
     // ===== Keydown
     document.removeEventListener('keydown', eventHandlers.keydown);
     eventHandlers.keydown = (event: KeyboardEvent) => {
-      KeyboardHandler(state, draw, download)(event);
+      KeyboardHandler(state, loopState, draw, restart, download)(event);
     };
     document.addEventListener('keydown', eventHandlers.keydown, false);
   };
@@ -149,17 +172,17 @@ const Page = (props: { sketch: Sketch }) => {
   const controlPanelUpdateHandler = (
     property: string,
     value: any,
-    updatedState: StringMap<any>,
+    // updatedState: StringMap<any>,
   ) => {
     params[property] = value;
     draw();
-    // regenerate();
   };
 
   /**
    * Run once on page load
    */
   useEffect(() => {
+    console.log('useEffect', initialized);
     // ===== Attach event handlers
     resetEventHandlers();
 
@@ -170,12 +193,7 @@ const Page = (props: { sketch: Sketch }) => {
     if (!initialized) {
       console.log('### ===== Sketch! ===== ###');
       // ===== Initialize Sketch
-      sketch.init({
-        canvas,
-        params,
-        rng: state.getImageRng(),
-        palette: new Palette(state.getColorRng()),
-      });
+      sketch.init(getSketchProps());
 
       setInitialized(true);
     }

--- a/src/demos/loop.ts
+++ b/src/demos/loop.ts
@@ -1,0 +1,49 @@
+import Sketch from '../sketch';
+import SketchProps from '../sketch/SketchProps';
+import FrameData from '../sketch/FrameData';
+import { Vec2 } from '@code-not-art/core';
+
+// const config: ConfigInput = {};
+// const params: Params = [];
+
+const draw = ({}: SketchProps) => {
+  // Nothing doing, checkout the loop!
+};
+
+const init = ({ canvas, data }: SketchProps) => {
+  console.log('init');
+  data.point = Vec2.origin();
+  data.direction = Vec2.ones();
+  data.speed = canvas.get.minDim() / 100;
+};
+
+const loop = (
+  { canvas, palette, rng, data }: SketchProps,
+  { frame, frameTime }: FrameData,
+) => {
+  canvas.fill(palette.colors[0]);
+  // console.log(`frame`, frame, frameTime, rng.next());
+  data.point = data.point.add(data.direction.scale(data.speed));
+  if (!data.point.within(canvas.get.size())) {
+    data.direction = data.direction.scale(-1);
+  }
+  canvas.draw.circle({
+    origin: data.point,
+    radius: canvas.get.minDim() / 4,
+    fill: palette.colors[1],
+  });
+  return false;
+};
+
+// const reset = ({}: SketchProps) => {};
+
+const Art: Sketch = new Sketch({
+  // config,
+  // params,
+  draw,
+  init,
+  loop,
+  // reset,
+});
+
+export default Art;

--- a/src/demos/loop.ts
+++ b/src/demos/loop.ts
@@ -1,36 +1,71 @@
-import Sketch from '../sketch';
+import Sketch, { Params } from '../sketch';
 import SketchProps from '../sketch/SketchProps';
 import FrameData from '../sketch/FrameData';
-import { Vec2 } from '@code-not-art/core';
+import { Constants, Gradient, Vec2, Utils } from '@code-not-art/core';
+const TAU = Constants.TAU;
 
 // const config: ConfigInput = {};
-// const params: Params = [];
+const params: Params = [
+  { key: 'speed', value: 2, min: 0, max: 10 },
+  { key: 'rotationSpeed', value: 1, min: 0, max: 10 },
+  { key: 'dotSize', value: 0.04, min: 0.005, max: 0.2, step: 0.001 },
+  { key: 'dotCount', value: 24, min: 1, max: 89, step: 1 },
+  { key: 'twists', value: 5, min: 1, max: 8, step: 1 },
+];
 
-const draw = ({}: SketchProps) => {
+const draw = ({ canvas, palette, data }: SketchProps) => {
   // Nothing doing, checkout the loop!
+  canvas.translate(canvas.get.size().scale(0.5));
+
+  // define the gradient in the draw step so that when the color is updated the gradient is regenerated.
+  // if this is done in the init, the gradient won't be updated until the whole image is refreshed.
+  // if this is done in the loop, it will be regenerated every frame which is unnecessary work
+  data.gradient = new Gradient(palette.colors[1], palette.colors[2]).loop();
 };
 
-const init = ({ canvas, data }: SketchProps) => {
-  console.log('init');
-  data.point = Vec2.origin();
-  data.direction = Vec2.ones();
-  data.speed = canvas.get.minDim() / 100;
+const init = ({ palette, data }: SketchProps) => {
+  data.angle = 0;
+  data.absoluteAngle = 0;
 };
 
 const loop = (
-  { canvas, palette, rng, data }: SketchProps,
-  { frame, frameTime }: FrameData,
+  { canvas, palette, rng, params, data }: SketchProps,
+  { frameTime }: FrameData,
 ) => {
+  const speed = params.speed as number;
+  const rotationSpeed = params.rotationSpeed as number;
+  const dotSize = params.dotSize as number;
+  const dotCount = params.dotCount as number;
+  const twists = params.twists as number;
+
+  const gradient = data.gradient as Gradient;
+
   canvas.fill(palette.colors[0]);
-  // console.log(`frame`, frame, frameTime, rng.next());
-  data.point = data.point.add(data.direction.scale(data.speed));
-  if (!data.point.within(canvas.get.size())) {
-    data.direction = data.direction.scale(-1);
-  }
-  canvas.draw.circle({
-    origin: data.point,
-    radius: canvas.get.minDim() / 4,
-    fill: palette.colors[1],
+
+  data.angle += ((frameTime / 10000) * TAU * speed) / twists;
+
+  data.absoluteAngle += (frameTime / 10000) * TAU * rotationSpeed;
+
+  Utils.repeat(dotCount, (i) => {
+    const repeatFraction = i / dotCount;
+    const angle = data.angle + TAU * repeatFraction;
+    const spinRadius = canvas.get.minDim() * 0.25;
+    const spinOffset = Vec2.unit()
+      .scale(canvas.get.minDim() * 0.15)
+      .rotate(TAU * repeatFraction);
+
+    const circleOrigin = Vec2.unit()
+      // .rotate(Math.cos(angle))
+      .rotate(angle * twists)
+      .scale(spinRadius)
+      .add(spinOffset)
+      .rotate(data.absoluteAngle);
+
+    canvas.draw.circle({
+      origin: circleOrigin,
+      radius: canvas.get.minDim() * dotSize,
+      fill: gradient.at(i / (dotCount > 1 ? dotCount - 1 : 1)),
+    });
   });
   return false;
 };
@@ -39,7 +74,7 @@ const loop = (
 
 const Art: Sketch = new Sketch({
   // config,
-  // params,
+  params,
   draw,
   init,
   loop,

--- a/src/demos/sketch.ts
+++ b/src/demos/sketch.ts
@@ -1,14 +1,13 @@
-import Sketch, { Params } from './sketch';
-import { ConfigInput } from './sketch/Config';
-import SketchProps from './sketch/SketchProps';
-// import FrameData from './sketch/FrameData';
 import { Vec2, Utils } from '@code-not-art/core';
+import Sketch, { Params } from '../sketch';
+import { ConfigInput } from '../sketch/Config';
+import SketchProps from '../sketch/SketchProps';
+// import FrameData from '../sketch/FrameData';
+// import StringMap from 'types/StringMap';
 const { repeat } = Utils;
 
+// const data: StringMap<any> = {};
 const config: ConfigInput = {
-  // width: 2160,
-  // height: 2160,
-  // seed: 'predictable randomness',
   menuDelay: 10,
 };
 const params: Params = [
@@ -37,8 +36,6 @@ const draw = ({ canvas, rng, palette, params }: SketchProps) => {
   const width = canvas.get.width() * canvasFill;
   const height = canvas.get.height() * canvasFill;
 
-  const minDim = Math.min(width, height);
-
   // Background
   canvas.fill(palette.colors[0]);
 
@@ -59,7 +56,7 @@ const draw = ({ canvas, rng, palette, params }: SketchProps) => {
   //   fill: palette.colors[1],
   // });
 
-  const circleRadius = minDim / gridWidth / 2;
+  const circleRadius = (canvas.get.minDim() * canvasFill) / gridWidth / 2;
 
   // Base layer dots
   repeat(gridWidth, (x) => {
@@ -128,9 +125,14 @@ const draw = ({ canvas, rng, palette, params }: SketchProps) => {
   });
 };
 
-// const init = ({}: SketchProps) => {};
+const init = ({}: SketchProps) => {
+  console.log('init');
+};
 
-// const loop = ({}: SketchProps, {}: FrameData) => {};
+// const loop = (
+//   { canvas, rng }: SketchProps,
+//   { frame, frameTime }: FrameData,
+// ): boolean => {};
 
 // const reset = ({}: SketchProps) => {};
 
@@ -141,6 +143,7 @@ const Art: Sketch = new Sketch({
   // init,
   // loop,
   // reset,
+  // data,
 });
 
 export default Art;

--- a/src/demos/sketch.ts
+++ b/src/demos/sketch.ts
@@ -143,7 +143,6 @@ const Art: Sketch = new Sketch({
   // init,
   // loop,
   // reset,
-  // data,
 });
 
 export default Art;

--- a/src/sketch/Sketch.ts
+++ b/src/sketch/Sketch.ts
@@ -7,7 +7,7 @@ export type SketchDefinition = {
   reset?: (props: SketchProps) => void;
   init?: (props: SketchProps) => void;
   draw: (props: SketchProps) => void;
-  loop?: (props: SketchProps, frameData: FrameData) => void;
+  loop?: (props: SketchProps, frameData: FrameData) => boolean;
   params?: Params;
   config?: ConfigInput;
 };
@@ -17,6 +17,7 @@ const defaultInit = () => {
 };
 const defaultLoop = () => {
   // Do nothing EVERY FRAME
+  return false;
 };
 const defaultReset = (props: SketchProps) => {
   props.canvas.clear();
@@ -25,7 +26,7 @@ const defaultReset = (props: SketchProps) => {
 class Sketch {
   init: (props: SketchProps) => void;
   draw: (props: SketchProps) => void;
-  loop: (props: SketchProps, frameData: FrameData) => void;
+  loop: (props: SketchProps, frameData: FrameData) => boolean;
   reset: (props: SketchProps) => void;
   params: Params;
   config: Config;

--- a/src/sketch/SketchProps.ts
+++ b/src/sketch/SketchProps.ts
@@ -7,6 +7,7 @@ type SketchProps = {
   palette: Palette;
   rng: Random;
   params: StringMap<any>;
+  data: StringMap<any>;
 };
 
 export default SketchProps;


### PR DESCRIPTION
Moved demo sketch code to `./demos` folder. This is not the desired end state for the repo as a demo, but is useful for now.

Introduced `data` to `SketchProps`. Animations that want to do dev with hot reloading should put any variables that persists from frame to frame into this data object so that hot reload doesn't crash the page.

Do not merge until we update the readme documentation to add a description of the data persistence for loops, and the keyboard inputs for animation pause (Enter) and restart animation/redraw (R)